### PR TITLE
Makes equalto consistent with equals

### DIFF
--- a/src/rules/equalto.js
+++ b/src/rules/equalto.js
@@ -19,7 +19,8 @@ export default (
   if (typeof arg === 'function') {
     arg = arg(value, row);
   }
-  if (row[arg] && row[arg] === value) {
+ 
+  if (value === arg) {
     return Promise.resolve();
   }
   return Promise.reject(msg(value, row, arg));


### PR DESCRIPTION
Equalto had a different implementation to equals beyond the use of a different operator. This change make the two functions consistent with one another.